### PR TITLE
chore(deps): bump 5 outdated dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 fastapi==0.109.0
 uvicorn[standard]==0.27.0
-python-multipart==0.0.6
-pydantic==2.5.3
-pyyaml==6.0.1
-aiohttp==3.9.1
+python-multipart==0.0.27
+pydantic==2.13.3
+pyyaml==6.0.3
+aiohttp==3.13.5
 aiofiles==23.2.1
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 gitpython==3.1.40
 requests==2.31.0
 jinja2==3.1.2


### PR DESCRIPTION
## Summary
Updates 5 pinned dependencies to their latest released versions: `python-multipart` 0.0.6->0.0.27, `pydantic` 2.5.3->2.13.3, `pyyaml` 6.0.1->6.0.3, `aiohttp` 3.9.1->3.13.5, `python-dotenv` 1.0.0->1.2.2.

## Why it matters
Keeping pinned dependencies current reduces exposure to known CVEs and ensures compatibility with downstream packages.

## Testing
Registry versions were checked first. The submission flow must also pass repo-local verification before opening this PR.