### PR TITLE
fix: tolerate large entity registry websocket responses

### DIFF
--- a/app/services/ha_websocket.py
+++ b/app/services/ha_websocket.py
@@ -9,6 +9,11 @@ from datetime import datetime
 logger = logging.getLogger('ha_cursor_agent')
 
 
+# Home Assistant's entity registry can be considerably larger than the default
+# 4 MiB aiohttp WebSocket receive limit on established installations.
+WEBSOCKET_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+
+
 class HAWebSocketClient:
     """
     Persistent WebSocket connection to Home Assistant
@@ -126,7 +131,11 @@ class HAWebSocketClient:
             self.session = aiohttp.ClientSession()
         
         try:
-            async with self.session.ws_connect(self.url) as ws:
+            async with self.session.ws_connect(
+                self.url,
+                max_msg_size=WEBSOCKET_MAX_MESSAGE_SIZE,
+                heartbeat=30.0,
+            ) as ws:
                 self.ws = ws
                 
                 # Step 1: Receive auth_required
@@ -160,12 +169,20 @@ class HAWebSocketClient:
                         except json.JSONDecodeError as e:
                             logger.error(f"Failed to parse WebSocket message: {e}")
                     
-                    elif msg.type == aiohttp.WSMsgType.CLOSED:
-                        logger.warning("WebSocket closed by server")
-                        break
-                    
-                    elif msg.type == aiohttp.WSMsgType.ERROR:
-                        logger.error(f"WebSocket error: {ws.exception()}")
+                    elif msg.type in (
+                        aiohttp.WSMsgType.CLOSE,
+                        aiohttp.WSMsgType.CLOSING,
+                        aiohttp.WSMsgType.CLOSED,
+                        aiohttp.WSMsgType.ERROR,
+                    ):
+                        log = logger.error if msg.type == aiohttp.WSMsgType.ERROR else logger.warning
+                        log(
+                            "WebSocket closed: type=%s close_code=%s exception=%r data=%r",
+                            msg.type.name,
+                            ws.close_code,
+                            ws.exception(),
+                            msg.data,
+                        )
                         break
         finally:
             self._connected = False
@@ -393,8 +410,25 @@ class HAWebSocketClient:
         Returns:
             List of entity registry entries with metadata (area_id, device_id, name, etc.)
         """
-        result = await self._send_message({'type': 'config/entity_registry/list'}, timeout=90.0)
-        return result or []
+        # This command only reads HA state, so retrying it once after a dropped
+        # connection is safe. Do not add generic retries to _send_message: that
+        # method is also used for state-changing commands.
+        for attempt in range(2):
+            try:
+                result = await self._send_message(
+                    {'type': 'config/entity_registry/list'}, timeout=90.0
+                )
+                return result or []
+            except ConnectionError:
+                if attempt:
+                    raise
+                logger.warning(
+                    "Entity registry request lost its WebSocket connection; retrying after reconnect"
+                )
+                await self.wait_for_connection(timeout=30.0)
+
+        # The loop always returns or raises; this makes the type contract clear.
+        return []
     
     async def get_entity_registry_entry(self, entity_id: str) -> dict:
         """
@@ -771,7 +805,6 @@ async def get_ws_client() -> HAWebSocketClient:
             raise Exception("WebSocket not connected after 30s. HA may be restarting.")
     
     return ha_ws_client
-
 
 
 


### PR DESCRIPTION
## Description

Fixes Home Assistant WebSocket disconnects triggered by `config/entity_registry/list`.

The agent authenticated successfully, but the socket closed immediately after requesting the entity registry. This broke automation listing because that path retrieves the full registry before applying search or pagination.

## Type of Change

<!-- Check the relevant option(s) -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvement

## Related Issues

None.

## Changes Made

- Set an explicit 16 MiB `max_msg_size` for the Home Assistant WebSocket.
- Add a 30-second WebSocket heartbeat.
- Log WebSocket message type, close code, exception, and message data on disconnect.
- Retry only the read-only entity-registry request once after reconnecting.

The retry is intentionally scoped to `config/entity_registry/list`; state-changing WebSocket commands are not retried.

## Testing

- Reproduced: automation listing consistently failed immediately after sending `config/entity_registry/list`.
- Confirmed unrelated small WebSocket requests still worked.
- Installed the patched agent as a parallel Home Assistant add-on on a separate port.
- Verified the patched build successfully listed gym automations through MCP.

**Tested with:**

- Home Assistant version: `2026.7.4`
- Add-on version: `2.10.48-dev.1` (parallel test build from this fix)
- Architecture: Not recorded
- MCP package version: `3.2.31`

**Test steps:**

1. Run an automation-list request with the unpatched add-on; it disconnected immediately after `config/entity_registry/list`.
2. Install and start the patched build as a parallel add-on instance.
3. Point the MCP client at the patched instance and call the automation-list endpoint with `search=gym`, `summary_only=true`, and `page_size=20`.
4. Confirm the request returns automation summaries successfully.

Static validation included Python compilation, AST parsing, YAML validation, and whitespace checks. A full pytest run was not available in the local checkout.

## API Changes

<!-- Only if this PR changes API endpoints -->

- [x] No API changes
- [ ] New endpoints added (documented below)
- [ ] Existing endpoints modified (backward compatible)
- [ ] Breaking API changes (documented in CHANGELOG)

**API changes details:**

None.

## Security & Privacy

<!-- Important for Home Assistant projects! -->

- [x] No sensitive data (tokens, passwords, IPs) included in code or commits
- [x] No credentials hardcoded
- [x] All example configs use placeholder values
- [x] Authentication/authorization properly handled

## Checklist

<!-- Check all that apply -->

- [x] Code follows the project's coding style
- [x] I have tested these changes locally with Home Assistant
- [x] Add-on builds successfully
- [ ] Documentation has been updated (if needed)
- [ ] CHANGELOG.md has been updated (if applicable)
- [ ] config.yaml version bumped (if needed)
- [x] No breaking changes (or documented if unavoidable)
- [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)

## Additional Context

This was tested using a parallel development add-on solely to avoid disturbing the existing production instance. The development add-on metadata and port changes are on a separate branch and are not part of this PR.

The explicit message-size limit addresses the large entity-registry response, while the heartbeat and expanded disconnect logging improve resilience and diagnosis if the connection is interrupted in the future.